### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -8,6 +8,8 @@
 # REGISTRY_PASSWORD
 
 name: Build and deploy Web MVC
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/vinaghost/TravianMapSqlAnalytics/security/code-scanning/3](https://github.com/vinaghost/TravianMapSqlAnalytics/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow:
- The `contents: read` permission is sufficient for checking out the repository.
- No other permissions are required unless explicitly needed for specific actions.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to individual jobs if different permissions are required for each job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
