### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -8,6 +8,10 @@
 # REGISTRY_PASSWORD
 
 name: Build and deploy Web MVC
+permissions:
+  contents: read
+  packages: write
+  deployments: write
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/vinaghost/TravianMapSqlAnalytics/security/code-scanning/2](https://github.com/vinaghost/TravianMapSqlAnalytics/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `packages: write` for pushing Docker images to the registry.
- `deployments: write` for executing deployment commands.

The `permissions` block can be added at the root level to apply to all jobs or at the job level for more granular control. In this case, adding it at the root level simplifies the configuration while ensuring all jobs adhere to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
