### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -8,6 +8,8 @@
 # REGISTRY_PASSWORD
 
 name: Build and deploy Web MVC
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/vinaghost/TravianMapSqlAnalytics/security/code-scanning/1](https://github.com/vinaghost/TravianMapSqlAnalytics/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file to explicitly define the permissions for the `GITHUB_TOKEN`. Since the workflow primarily involves checking out code, building Docker images, and deploying them, the minimal required permission is `contents: read`. This ensures that the token has only read access to the repository contents and no write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
