### PR TITLE
Potential fix for code scanning alert no. 5: Unsafe jQuery plugin

### DIFF
--- a/WebMVC/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/WebMVC/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -1073,6 +1073,11 @@ $.extend( $.validator, {
 				throw new Error("Invalid element provided to validationTargetFor.");
 			}
 
+			// Sanitize the element if it is a string
+			if (typeof element === "string") {
+				element = this.escapeCssMeta(element);
+			}
+
 			// Always apply ignore filter
 			return $( element ).not( this.settings.ignore )[ 0 ];
 		},


### PR DESCRIPTION
Potential fix for [https://github.com/vinaghost/TravianMapSqlAnalytics/security/code-scanning/5](https://github.com/vinaghost/TravianMapSqlAnalytics/security/code-scanning/5)

To fix the issue, we need to ensure that any string passed to the `validationTargetFor` function is properly sanitized before being used as a selector in the `$()` function. This can be achieved by escaping any potentially dangerous characters in the string using the existing `escapeCssMeta` function. This function is already defined in the codebase and is designed to escape special characters in CSS selectors.

The fix involves modifying the `validationTargetFor` function to sanitize the `element` parameter if it is a string. Specifically:
1. Check if `element` is a string.
2. If it is, pass it through the `escapeCssMeta` function before using it in the `$()` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
